### PR TITLE
Introduce GwtReact components based on React's ES6 classes

### DIFF
--- a/src/gwt/react/client/api/React.java
+++ b/src/gwt/react/client/api/React.java
@@ -97,9 +97,9 @@ public class React {
         return createElement(ComponentUtils.getCtorFn(type), props, child);
     }
 
-    public static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ReactElement<P, T> createElement(ComponentConstructorFn<P> type, P props);
-    public static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ReactElement<P, T> createElement(ComponentConstructorFn<P> type, P props, String value);
-    public static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ReactElement<P, T> createElement(ComponentConstructorFn<P> type, P props, ReactElement<?, ?> ...child);
+    public static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ReactElement<P, T> createElement(ComponentConstructorFn<P, T> type, P props);
+    public static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ReactElement<P, T> createElement(ComponentConstructorFn<P, T> type, P props, String value);
+    public static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ReactElement<P, T> createElement(ComponentConstructorFn<P, T> type, P props, ReactElement<?, ?> ...child);
 
     /**
      * <p>Clone and return a new ReactElement using element as the starting point. The resulting

--- a/src/gwt/react/client/components/ComponentConstructorFn.java
+++ b/src/gwt/react/client/components/ComponentConstructorFn.java
@@ -1,11 +1,17 @@
 package gwt.react.client.components;
 
+import gwt.interop.utils.client.plainobjects.JsPlainObj;
+import gwt.react.client.proptypes.BaseProps;
 import jsinterop.annotations.JsFunction;
 
-/*
+/**
  * A constructor function for a React Component
  */
 @JsFunction
-public interface ComponentConstructorFn<P> {
-    void onCreate(P props);
+public interface ComponentConstructorFn<P extends BaseProps, T extends Component<P, ? extends JsPlainObj>> {
+	/**
+	 * This method is not supposed to be called by the user directly, as it will not have the expected effect.
+	 * Calling a JavaScript function with 'new' is not supported from Java.
+	 */
+    T create(P props);
 }

--- a/src/gwt/react/client/components/ComponentUtils.java
+++ b/src/gwt/react/client/components/ComponentUtils.java
@@ -12,14 +12,15 @@ public class ComponentUtils {
     private ComponentUtils() {
     }
 
-    private static StringMap<ComponentConstructorFn> constructorLookup = JsStringMap.create() ;
+    private static StringMap<ComponentConstructorFn<?, ?>> constructorLookup = JsStringMap.create() ;
 
-    public static <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ComponentConstructorFn<P> getCtorFn(Class<T> cls) {
+    public static <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ComponentConstructorFn<P, T> getCtorFn(Class<T> cls) {
         return getCtorFn(cls.getName());
     }
 
-    public static <P extends BaseProps> ComponentConstructorFn<P> getCtorFn(String className) {
-        ComponentConstructorFn<P> fn = constructorLookup.get(className);
+    public static <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ComponentConstructorFn<P, T> getCtorFn(String className) {
+        @SuppressWarnings("unchecked")
+		ComponentConstructorFn<P, T> fn = (ComponentConstructorFn<P, T>)constructorLookup.get(className);
 
         if (fn == null) {
             fn = getJSConstructorFn(className);
@@ -33,7 +34,7 @@ public class ComponentUtils {
     /**
      * TODO find a more efficient way of obtaining the constructor function
      */
-    private static native <P extends BaseProps> ComponentConstructorFn<P> getJSConstructorFn(String className) /*-{
+    private static native <P extends BaseProps, S extends JsPlainObj, T extends Component<P, S>> ComponentConstructorFn<P, T> getJSConstructorFn(String className) /*-{
         var namespaces = className.split(".");
         var context = $wnd;
 


### PR DESCRIPTION
That's a second attempt - which - compared to #3:
* Has no backwards incompatibility changes
* In the name of simplicity, does not support React contexts (yet). But please see #6
* Has a much smaller change surface

Again, the major benefit of this work is that with ES6 components, the component's constructor will **not** be called until the component is instantiated by React itself. There is a clear distinction between the component object, and its Java Class<> instance. It is the Class<> instance which is registered when calling `React.createElement`

The philosophy of this change is to:
* Not to expose an API as public, if it is not. Thus, `render()`, as well as the component's lifecycle methods (`shouldComponentUpdate` & friends) are protected rather than public methods. That's also one of the reasons why they are not isolated in a separate Java "lifecycle" interface - that would make them public.
* Favor type safety and enable IDE code completion of the method names - that's why the above component lifecycle methods are exposed as real, existing Java methods that the user can override.