### PR TITLE
#13

### DIFF
--- a/src/gwt/react/client/elements/DOMElement.java
+++ b/src/gwt/react/client/elements/DOMElement.java
@@ -1,9 +1,10 @@
 package gwt.react.client.elements;
 
 import gwt.react.client.proptypes.BaseProps;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
-@JsType(isNative = true)
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class DOMElement<P extends BaseProps> extends ReactElement<P, String> {
     /**
      * Objects of this class cannot be directly instantiated by the user.

--- a/src/gwt/react/client/elements/ReactElement.java
+++ b/src/gwt/react/client/elements/ReactElement.java
@@ -1,9 +1,10 @@
 package gwt.react.client.elements;
 
 import gwt.react.client.proptypes.BaseProps;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
-@JsType(isNative = true)
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class ReactElement<P extends BaseProps, T> {
     public T type;
     public P props;


### PR DESCRIPTION
Confirmed that annotating `ReactElement` and `DOMElement` as described fixes all GWT cast exceptions for me.